### PR TITLE
Check for missing servers on startup

### DIFF
--- a/src/helpers.py
+++ b/src/helpers.py
@@ -170,6 +170,27 @@ async def list_packages(logger: logging.Logger, ctx: discord.ApplicationContext)
 
     await paginator.respond(ctx.interaction, ephemeral=False)
 
+def check_guilds(logger: logging.Logger, bot: discord.Bot):
+    conn = sqlite3.connect("/data/data.sqlite3")
+
+    cur = conn.cursor()
+
+    cur.execute("SELECT guild_id FROM Guilds")
+    db_guild_ids = [ str(guild_id[0]) for guild_id in cur.fetchall() ]
+
+    logger.debug(f"Guilds in database: {db_guild_ids}")
+
+    conn.close()
+
+    bot_guild_ids = [ str(guild.id) for guild in bot.guilds ]
+
+    logger.debug(f"Guilds the bot has joined: {bot_guild_ids}")
+
+    for guild_id in bot_guild_ids:
+        if guild_id not in db_guild_ids:
+            logger.info(f"Adding guild {guild_id}")
+            sqlite3_handler.insert_guild(logger, str(guild_id))
+
 def create_database(logger: logging.Logger):
     conn = sqlite3.connect("/data/data.sqlite3")
     cur = conn.cursor()

--- a/src/main.py
+++ b/src/main.py
@@ -169,9 +169,10 @@ async def update_ids():
 @update_ids.before_loop
 async def update_ids_before_loop():
     await bot.wait_until_ready()
+    helpers.check_guilds(logger, bot)   # Putting this here because the bot needs to be connected and ready for the check to work
 
 if __name__ == "__main__":
-    dictConfig(LogConfig().dict())
+    dictConfig(LogConfig().model_dump())
     logger = logging.getLogger(getenv("LOG_NAME", "courier-tracking-bot"))
 
     helpers.check_database(logger)


### PR DESCRIPTION
If the bot if offline and someone invites it to a server then it won't add that server to the database. There was nothing later to check for these new servers and add them. The pull requests creates that check so now on startup it will find any missing servers and add them to the database.